### PR TITLE
Fix Xcode project generation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,8 +141,9 @@ function(set_output_name project_name)
     )
 endfunction(set_output_name)
 
-add_library(${STATIC_NAME} STATIC $<TARGET_OBJECTS:${OBJLIB_NAME}>)
-add_library(${PROJECT_NAME} SHARED $<TARGET_OBJECTS:${OBJLIB_NAME}>)
+# Add dummy file to library sources to workaround Xcode project generation issues
+add_library(${STATIC_NAME} STATIC $<TARGET_OBJECTS:${OBJLIB_NAME}> src/Dummy.cpp)
+add_library(${PROJECT_NAME} SHARED $<TARGET_OBJECTS:${OBJLIB_NAME}> src/Dummy.cpp)
 
 function(set_target_link_libraries project_name)
     target_link_libraries(${project_name} PRIVATE

--- a/src/Dummy.cpp
+++ b/src/Dummy.cpp
@@ -1,0 +1,4 @@
+// Copyright 2019 Caffeine Inc. All rights reserved.
+
+// This file exists purely to work around cmake Xcode project generation issues
+// for targets that link to object targets


### PR DESCRIPTION
Add a dummy source file to static and shared library targets to workaround Xcode issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/libcaffeine/24)
<!-- Reviewable:end -->
