### PR TITLE
Fix incorrect HTTP timeout value

### DIFF
--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -62,7 +62,7 @@ namespace caff {
     std::string clientVersion;
 
     class ScopedCurl final {
-        static auto constexpr timeoutSeconds = 1l;
+        static auto constexpr timeoutSeconds = 10l;
         static auto constexpr lowSpeedBps = 100'000l;
 
     public:


### PR DESCRIPTION
Was missing the 0 on 10 seconds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/libcaffeine/30)
<!-- Reviewable:end -->
