### PR TITLE
Pass connection to websocket callback.

### DIFF
--- a/src/WebsocketApi.hpp
+++ b/src/WebsocketApi.hpp
@@ -24,9 +24,9 @@ namespace caff {
         optional<Connection> connect(
                 std::string url,
                 std::string name,
-                std::function<void()> openedCallback,
-                std::function<void(ConnectionEndType)> endedCallback,
-                std::function<void(std::string const &)> messageReceivedCallback);
+                std::function<void(Connection)> openedCallback,
+                std::function<void(Connection, ConnectionEndType)> endedCallback,
+                std::function<void(Connection, std::string const &)> messageReceivedCallback);
 
         void sendMessage(Connection const & connection, std::string const & message);
 


### PR DESCRIPTION
It turns out it's useful to have access to the connection in the websocket callbacks. This will make writing the graphql subscription easier since there are certain messages that must be sent when the connection opens.

An alternative is to have the graphql subscription be an object instead of a function, which could also manage things like refreshing credentials. At the moment I want to hold off on that to reduce the amount of stateful objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/libcaffeine/69)
<!-- Reviewable:end -->
