### PR TITLE
Make sure the stage subscription has opened before going live.

### DIFF
--- a/src/Broadcast.hpp
+++ b/src/Broadcast.hpp
@@ -99,8 +99,10 @@ namespace caff {
         optional<std::string> broadcastId;
         std::string streamUrl;
         std::shared_ptr<GraphqlSubscription<caffql::Subscription::StageField>> subscription;
-        std::atomic<bool> feedHasAppearedInSubscription;
-        std::atomic<bool> stageHasGoneLiveInSubscription;
+
+        enum class SubscriptionState { None, Open, FeedHasAppeared, StageHasGoneLive };
+        SubscriptionState subscriptionState{};
+        std::promise<bool> subscriptionOpened;
 
         AudioDevice * audioDevice;
         VideoCapturer * videoCapturer;


### PR DESCRIPTION
This ensures the client is capable of heartbeating their stage through the subscription.
Also moves various subscription states into single SubscriptionState enum.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/libcaffeine/77)
<!-- Reviewable:end -->
