### PR TITLE
Use WebRTC's logic to setup the ssl context root certificates.

### DIFF
--- a/src/WebsocketApi.cpp
+++ b/src/WebsocketApi.cpp
@@ -2,6 +2,7 @@
 
 #include "WebsocketApi.hpp"
 #include "ErrorLogging.hpp"
+#include "rtc_base/opensslutility.h"
 
 namespace caff {
 
@@ -13,9 +14,12 @@ namespace caff {
 
         client.set_tls_init_handler(
                 [](websocketpp::connection_hdl connection) -> std::shared_ptr<websocketpp::lib::asio::ssl::context> {
-                    // TODO: Look more into what should be done here
                     auto context = std::make_shared<asio::ssl::context>(asio::ssl::context::sslv23);
-                    context->set_default_verify_paths();
+                    if (rtc::openssl::LoadBuiltinSSLRootCertificates(context->native_handle())) {
+                        LOG_DEBUG("Loaded built in ssl root certificates");
+                    } else {
+                        LOG_ERROR("Could not load built in ssl root certificates");
+                    }
                     context->set_verify_mode(asio::ssl::verify_peer);
                     return context;
                 });


### PR DESCRIPTION
This uses WebRTC's logic to load ssl certificates instead of `set_default_verify_paths`, which apparently doesn't work on windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/libcaffeine/78)
<!-- Reviewable:end -->
