### PR TITLE
Address several possible race conditions.

### DIFF
--- a/src/Broadcast.hpp
+++ b/src/Broadcast.hpp
@@ -75,6 +75,10 @@ namespace caff {
 
         caff_ConnectionQuality getConnectionQuality();
 
+        std::string const & getClientId() const {
+            return clientId;
+        }
+
     private:
         enum class State { Offline, Starting, Streaming, Live, Stopping };
         std::atomic<State> state{ State::Offline };

--- a/src/Instance.cpp
+++ b/src/Instance.cpp
@@ -164,13 +164,6 @@ namespace caff {
             return caff_ResultAlreadyBroadcasting;
         }
 
-        auto dispatchFailure = [=](caff_Result error) {
-            taskQueue.PostTask([=] {
-                endBroadcast();
-                failedCallback(error);
-            });
-        };
-
         broadcast = std::make_shared<Broadcast>(
                 *sharedCredentials,
                 userInfo->username,
@@ -179,6 +172,21 @@ namespace caff {
                 std::move(gameId),
                 audioDevice,
                 factory);
+
+        auto dispatchFailure = [=, clientId = broadcast->getClientId()](caff_Result error) {
+            taskQueue.PostTask([=, clientId = std::move(clientId)] {
+                {
+                    std::lock_guard<std::mutex> lock(broadcastMutex);
+                    if (!broadcast || broadcast->getClientId() != clientId) {
+                        LOG_DEBUG("Failed callback called after stopping broadcast");
+                        return;
+                    }
+                }
+                endBroadcast();
+                failedCallback(error);
+            });
+        };
+
         broadcast->start(startedCallback, dispatchFailure);
         return caff_ResultSuccess;
     }
@@ -191,8 +199,9 @@ namespace caff {
     void Instance::endBroadcast() {
         std::lock_guard<std::mutex> lock(broadcastMutex);
         if (broadcast) {
-            // Asynchronously end the broadcast so we don't block this thread
-            std::thread([broadcast = std::move(broadcast)] { broadcast->stop(); }).detach();
+            broadcast->stop();
+            // Asynchronously destroy the broadcast so we don't block this thread
+            std::thread([broadcast = std::move(broadcast)] { }).detach();
         }
     }
 


### PR DESCRIPTION
Use broadcast transition state for state transitions that depend on a previous state.
When failing to transition to live set the stage to not live.
Only end a broadcast from the failed callback when it matches the instance's current broadcast.
Stop a broadcast synchronously to prevent weird issues from starting a broadcast when another is stopping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/libcaffeine/80)
<!-- Reviewable:end -->
