### PR TITLE
Fix some third-party log messages going to stdout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(libcaffeine VERSION 0.6)
+project(libcaffeine VERSION 0.7)
 
 ################################################################################
 # Setup / Bootstrap


### PR DESCRIPTION
* libcurl requests all use a "writefunc" to capture the response
* libx264 and websocketpp log messages are directed through RTC logger

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/libcaffeine/90)
<!-- Reviewable:end -->
