### PR TITLE
Integrate API to get encoder setting

### DIFF
--- a/src/Broadcast.cpp
+++ b/src/Broadcast.cpp
@@ -159,7 +159,8 @@ namespace caff {
         transitionState(State::Offline, State::Starting);
 
         auto info = getEncoderInfo(sharedCredentials);
-        int targetBitrate = info->setting.bitrate > 0 ? info->setting.bitrate : maxBitsPerSecond;
+        int targetBitrate = info.has_value() && info->setting.bitrate > 0 ? info->setting.bitrate : maxBitsPerSecond;
+        LOG_DEBUG("Setting target bitrate: %d", targetBitrate);
 
         broadcastThread = std::thread([=] {
             setupSubscription();

--- a/src/Broadcast.cpp
+++ b/src/Broadcast.cpp
@@ -158,6 +158,9 @@ namespace caff {
         this->failedCallback = failedCallback;
         transitionState(State::Offline, State::Starting);
 
+        auto info = getEncoderInfo(sharedCredentials);
+        int targetBitrate = info->setting.bitrate > 0 ? info->setting.bitrate : maxBitsPerSecond;
+
         broadcastThread = std::thread([=] {
             setupSubscription();
 
@@ -197,8 +200,8 @@ namespace caff {
             peerConnection->AddStream(mediaStream);
 
             webrtc::BitrateSettings bitrateOptions;
-            bitrateOptions.start_bitrate_bps = maxBitsPerSecond;
-            bitrateOptions.max_bitrate_bps = maxBitsPerSecond;
+            bitrateOptions.start_bitrate_bps = targetBitrate;
+            bitrateOptions.max_bitrate_bps = targetBitrate;
             peerConnection->SetBitrate(bitrateOptions);
 
             rtc::scoped_refptr<CreateSessionDescriptionObserver> creationObserver =

--- a/src/RestApi.hpp
+++ b/src/RestApi.hpp
@@ -92,6 +92,18 @@ namespace caff {
         caff_ConnectionQuality connectionQuality;
     };
 
+    struct EncoderSettings {
+        int width;
+        int height;
+        int bitrate;
+        int framerate;
+    };
+
+    struct EncoderInfoResponse {
+        std::string encoderType;
+        EncoderSettings setting;
+    };
+
     std::chrono::duration<long long> backoffDuration(size_t tryNum);
 
     optional<HeartbeatResponse> heartbeatStream(std::string const & streamUrl, SharedCredentials & creds);
@@ -119,6 +131,8 @@ namespace caff {
     void sendWebrtcStats(SharedCredentials & creds, Json const & report);
 
     optional<Json> graphqlRawRequest(SharedCredentials & creds, Json const & requestJson);
+
+    optional<EncoderInfoResponse> getEncoderInfo(SharedCredentials & creds);
 
     template <typename OperationField, typename... Args>
     optional<typename OperationField::ResponseData> graphqlRequest(SharedCredentials & creds, Args const &... args) {

--- a/src/Serialization.cpp
+++ b/src/Serialization.cpp
@@ -49,6 +49,15 @@ namespace caff {
         get_value_to(json, "connection_quality", response.connectionQuality);
     }
 
+    void from_json(Json const & json, EncoderInfoResponse & response) {
+        get_value_to(json, "encoder_type", response.encoderType);
+
+        get_value_to(json["encoder_setting"], "bitrate", response.setting.bitrate);
+        get_value_to(json["encoder_setting"], "framerate", response.setting.framerate);
+        get_value_to(json["encoder_setting"], "width", response.setting.width);
+        get_value_to(json["encoder_setting"], "height", response.setting.height);
+    }
+
     static bool isWhitelistedReportType(webrtc::StatsReport::StatsType type) {
         switch (type) {
         case webrtc::StatsReport::kStatsReportTypeSsrc:

--- a/src/Serialization.hpp
+++ b/src/Serialization.hpp
@@ -53,6 +53,7 @@ namespace caff {
     void from_json(Json const & json, GameInfo & gameInfo);
     void to_json(Json & json, IceInfo const & iceInfo);
     void from_json(Json const & json, HeartbeatResponse & response);
+    void from_json(Json const & json, EncoderInfoResponse & response);
 
     // The WebRTC types fail nlohmann's "compatibility" checks when using the to_json overload, either as a free
     // function or as an adl_serializer specialization

--- a/src/Urls.cpp
+++ b/src/Urls.cpp
@@ -17,6 +17,7 @@ namespace caff {
     std::string const apiEndpoint = "https://api." + caffeineDomain;
     std::string const realtimeEndpoint = "https://realtime." + caffeineDomain;
     std::string const eventsEndpoint = "https://events." + caffeineDomain;
+    std::string const lakituEndpoint = "https://lakitu." + caffeineDomain;
 
     std::string const versionCheckUrl = apiEndpoint + "/v1/version-check";
     std::string const signInUrl = apiEndpoint + "/v1/account/signin";
@@ -26,6 +27,8 @@ namespace caff {
     std::string const realtimeGraphqlUrl = realtimeEndpoint + "/public/graphql/query";
 
     std::string const broadcastMetricsUrl = eventsEndpoint + "/v1/broadcast_metrics";
+
+    std::string const encoderInfoUrl = lakituEndpoint + "/v2/encoderselection";
 
     std::string getUserUrl(std::string const & id) { return apiEndpoint + "/v1/users/" + id; }
 

--- a/src/Urls.hpp
+++ b/src/Urls.hpp
@@ -15,6 +15,7 @@ namespace caff {
     extern std::string const getGamesUrl;
     extern std::string const realtimeGraphqlUrl;
     extern std::string const broadcastMetricsUrl;
+    extern std::string const encoderInfoUrl;
 
     std::string getUserUrl(std::string const & id);
     std::string broadcastUrl(std::string const & id);

--- a/tests/src/unit-serialization.cpp
+++ b/tests/src/unit-serialization.cpp
@@ -56,3 +56,22 @@ TEST_CASE("webrtc stats serialize") {
 
     CHECK(serializeWebrtcStats(reports) == expected);
 }
+
+TEST_CASE("Deserializes encoder info response correctly") {
+    Json infoResponseJson = {
+        { "encoder_type", "default" },
+        { "encoder_setting", {
+            { "width", 1280 },
+            { "height", 720 },
+            { "bitrate", 3500000 },
+            { "framerate", 60 },
+        }}
+    };
+
+    EncoderInfoResponse info = infoResponseJson;
+    CHECK(info.encoderType == "default");
+    CHECK(info.setting.width == 1280);
+    CHECK(info.setting.height == 720);
+    CHECK(info.setting.bitrate == 3500000);
+    CHECK(info.setting.framerate == 60);
+}


### PR DESCRIPTION
Adds a new API call to the backend to get the encoder settings
for the current specific user.

Currently only supports adjusting encoding bitrate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/libcaffeine/93)
<!-- Reviewable:end -->
