### PR TITLE
Set target bitrate to the video RTP sender

### DIFF
--- a/src/X264Encoder.cpp
+++ b/src/X264Encoder.cpp
@@ -217,7 +217,7 @@ namespace caff {
         encoderParams.i_height = height;
         encoderParams.i_fps_den = 1;
         encoderParams.i_fps_num = 30;
-        encoderParams.i_level_idc = 31;
+        encoderParams.i_level_idc = 42;
 
         // CPU settings
         // use single thread encoding since multi-threaded may cause some issue on


### PR DESCRIPTION
The RTP sender needs to be set with the same target bitrate as the one in peer connection in order for the target bitrate value be propagated all the way down to the video encoder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/libcaffeine/95)
<!-- Reviewable:end -->
