### PR TITLE
Support 60fps 

### DIFF
--- a/src/VideoCapturer.hpp
+++ b/src/VideoCapturer.hpp
@@ -13,7 +13,7 @@ namespace caff {
 
     class VideoCapturer : public cricket::VideoCapturer {
     public:
-        VideoCapturer() {}
+        VideoCapturer();
         VideoCapturer(VideoCapturer const &) = delete;
         VideoCapturer & operator=(VideoCapturer const &) = delete;
         virtual ~VideoCapturer() {}
@@ -32,8 +32,11 @@ namespace caff {
         virtual bool IsScreencast() const override;
         virtual bool GetPreferredFourccs(std::vector<uint32_t> * fourccs) override;
 
+        void SetFramerateLimit(int32_t framerate);
+
     private:
         std::chrono::microseconds lastTimestamp{ std::chrono::seconds::min() };
+        std::chrono::microseconds interFrameLimit;
     };
 
 }  // namespace caff

--- a/src/X264Encoder.hpp
+++ b/src/X264Encoder.hpp
@@ -50,6 +50,7 @@ namespace caff {
         int height = 0;
         float maxFrameRate = 0.0f;
         uint32_t targetKbps = 0;
+        uint32_t targetFps = 30;
         webrtc::VideoCodecMode mode = webrtc::VideoCodecMode::kRealtimeVideo;
 
         // H.264 specifc parameters


### PR DESCRIPTION
This PR adds 60 fps support to broadcasting. 

If a broadcaster is allowed to broadcast at 60fps, this will set the video capturer to allow up to 60fps input. In addition, the encoder will dynamically adjust the encoding fps based on the input capturer fps. If the input goes above the high threshold (50) it will switch to 60fps; likewise, if it drops below the low threshold (35) it will switch down to encoding at 30fps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/libcaffeine/96)
<!-- Reviewable:end -->
