### PR TITLE
Prevent encoding at 60 fps if bitrate is 2Mbps only

### DIFF
--- a/src/Broadcast.cpp
+++ b/src/Broadcast.cpp
@@ -164,7 +164,10 @@ namespace caff {
         auto info = getEncoderInfo(sharedCredentials);
         if (info.has_value()) {
             targetBitrate = info->setting.targetBitrate > 0 ? info->setting.targetBitrate : maxBitsPerSecond;
-            targetFps = info->setting.framerate > 0 ? info->setting.framerate : maxFps;
+
+            if (targetBitrate > maxBitsPerSecond && info->setting.framerate > maxFps) {
+                targetFps = info->setting.framerate;
+            }
         }
 
         LOG_DEBUG("Setting target bitrate: %d", targetBitrate);


### PR DESCRIPTION
Right now on caffeine.tv, we limit the default encoding bitrate to be 2Mbps and capturing at 30 fps. For some specific users, we will potentially allow up to 3.5-4Mbps at 60 fps. 

This PR addresses if caffeine.tv accidentally puts a user at 60 fps but did not increase the target bitrate to above 2Mbps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/caffeinetv/libcaffeine/97)
<!-- Reviewable:end -->
