### PR TITLE
[CAP-1547] Increase title length limit to 255 characters

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -4,7 +4,7 @@ setlocal
 set BUILD_DIR64="build64"
 set BUILD_DIR32="build32"
 set DEST_DIR="dist"
-set PACKAGE_NAME="libcaffeine-v0.6.5-windows"
+set PACKAGE_NAME="libcaffeine-v0.6.6-windows"
 set BIN_DIR64="%PACKAGE_NAME%\bin64"
 set LIB_DIR64="%PACKAGE_NAME%\lib64"
 set BIN_DIR32="%PACKAGE_NAME%\bin32"

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@
 
 # define constants 
 BUILD_DIR="build"
-PACKAGE_NAME="libcaffeine-v0.7-macos"
+PACKAGE_NAME="libcaffeine-v0.6.6-macos"
 BIN_DIR="$PACKAGE_NAME/bin$(getconf LONG_BIT)"
 LIB_DIR="$PACKAGE_NAME/lib$(getconf LONG_BIT)"
 

--- a/src/Policy.hpp
+++ b/src/Policy.hpp
@@ -32,7 +32,7 @@ namespace caff {
     // Stage
     char constexpr defaultTitle[] = "LIVE on Caffeine!";
     char constexpr seventeenPlusTag[] = "[17+] ";
-    size_t constexpr maxTitleLength = 60;
+    size_t constexpr maxTitleLength = 255;
 
 
     // Helpers


### PR DESCRIPTION
- Currently title length limit is 60 , this increase title limit to 255. 
- Also updated package name for windows and macOS 
[[CAP-1547](https://caffeinetv.atlassian.net/browse/CAP-1547)]